### PR TITLE
Fix: VM was being created with the incorrect username for SSH

### DIFF
--- a/yandex_cloud/modules/instance/main.tf
+++ b/yandex_cloud/modules/instance/main.tf
@@ -39,7 +39,7 @@ resource "yandex_compute_instance" "ydb-static-nodes" {
   }
 
   metadata = {
-    ssh-keys = "var.module_user:${file(var.module_ssh_key_pub_path)}"
+    ssh-keys = "${var.module_user}:${file(var.module_ssh_key_pub_path)}"
   }
 
 }


### PR DESCRIPTION
Fixed an issue where the VM was being created with the incorrect username for SSH connections ('ubuntu' by default). This commit updates the username to the correct value, ensuring smooth SSH access to the VM.