### PR TITLE
Update image_id from ubuntu-22-04-lts-v20230828  to ubuntu-22-04-lts-v20251016

### DIFF
--- a/yandex_cloud/variables.tf
+++ b/yandex_cloud/variables.tf
@@ -67,7 +67,7 @@ variable "instance_hostname" {
 
 variable "instance_image_id" {
   type = string
-  default = "fd8clogg1kull9084s9o"
+  default = "fd8498pb5smsd5ch4gid"
   description = "Ubuntu 22.04 LTS image. Run `yc compute image list --folder-id standard-images` to get a list of available OS images."
 }
 


### PR DESCRIPTION
…v20251016

yc compute image get fd8clogg1kull9084s9o
id: fd8clogg1kull9084s9o
folder_id: standard-images
created_at: "2023-08-28T10:53:41Z"
name: ubuntu-22-04-lts-v20230828
description: ubuntu 22.04 lts
family: ubuntu-2204-lts
storage_size: "8128561152"
min_disk_size: "8589934592"
product_ids:
  - f2e2tpvtcfal3uv289dl status: READY
os:
  type: LINUX
pooled: true
hardware_generation:
  legacy_features:
    pci_topology: PCI_TOPOLOGY_V1


id: fd8498pb5smsd5ch4gid
folder_id: standard-images
created_at: "2025-10-16T09:04:00Z"
name: ubuntu-22-04-lts-v20251016
description: Ubuntu 22.04 lts v20251010030509
labels:
  version: "20251010030509"
family: ubuntu-2204-lts
storage_size: "3200253952"
min_disk_size: "8589934592"
product_ids:
  - f2esqeg4pqbtdofd3kh9 status: READY
os:
  type: LINUX
pooled: true
hardware_generation:
  legacy_features:
    pci_topology: PCI_TOPOLOGY_V2